### PR TITLE
feat: add app version in meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       name="%GRAASP_TEMPLATE_FULL_NAME%"
       content="A Graasp App created using a template."
     />
+    <meta name="version-info" content="%REACT_APP_VERSION%" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
This PR adds the app version in a meta tag to ease debugging a deployed frontend. 
It makes it possible to check which version of the app is currently served to the client.

closes #13 