### PR TITLE
fix: rename sentry dsn var name

### DIFF
--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -5,6 +5,7 @@ type SentryConfigType = {
   dsn: string;
   environment: string;
   tracesSampleRate: number;
+  release: string;
 };
 
 export const generateSentryConfig = (): SentryConfigType => {
@@ -25,8 +26,9 @@ export const generateSentryConfig = (): SentryConfigType => {
   }
 
   return {
-    dsn: (!window.Cypress && process.env.SENTRY_DSN) || '',
+    dsn: (!window.Cypress && process.env.REACT_APP_SENTRY_DSN) || '',
     environment: SENTRY_ENVIRONMENT,
     tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
+    release: process.env.REACT_APP_VERSION || 'no version',
   };
 };

--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -29,6 +29,6 @@ export const generateSentryConfig = (): SentryConfigType => {
     dsn: (!window.Cypress && process.env.REACT_APP_SENTRY_DSN) || '',
     environment: SENTRY_ENVIRONMENT,
     tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
-    release: process.env.REACT_APP_VERSION || 'no version',
+    release: process.env.REACT_APP_VERSION || 'undefined',
   };
 };


### PR DESCRIPTION
This PR fixes the same of the sentry DSN variable. It is passed as `REACT_APP_SENTRY_DSN` by the graasp-deploy workflows.

closes #14
